### PR TITLE
ACOS-ID support for the Austrian Middleware

### DIFF
--- a/middleware/2023-01-11-1.2.23011.59136.md
+++ b/middleware/2023-01-11-1.2.23011.59136.md
@@ -1,0 +1,28 @@
+---
+authors: poscreator
+slug: middleware/1.2.23011.59136
+tags: [Middleware, Austria]
+---
+
+# Middleware 1.2.23011.59136 (Austria)
+In this version of the Austrian Middleware, we've added support for the newly released A-Trust ACOS-ID smartcards to the `fiskaltrust.signing.atapdu` package.
+
+<!--truncate-->
+
+:::caution
+
+Version 1.2 of the Middleware is meant for the Austrian and French market only, customers in Germany have to use version 1.3. We will unify these experiences in an upcoming version.
+
+:::
+
+## Feature: A-Trust ACOS-ID smartcard support
+We've extended the Austrian Middleware to now be fully compatible with the newly released ACOS-ID smartcards from A-Trust. The SCU automatically detects the used smartcard, no further implementation effort is required.
+
+### Affected packages:
+- _fiskaltrust.signing.atapdu v1.2.23011.59136_
+
+## Next steps in the Middleware
+We will focus on finalizing the next version of the fiskaltrust.Launcher in the next sprints.
+This version is developed open-source, and our first public preview can be found in the public repository https://github.com/fiskaltrust/middleware-launcher.
+
+As always, we're happy to hear feedback and suggestions via [feedback+middleware@fiskaltrust.cloud](mailto:feedback+middleware@fiskaltrust.cloud) or directly via issues in our GitHub repositories.


### PR DESCRIPTION
Added the release notes for ACOS-ID support in version 1.2.23011.59136.