### PR TITLE
Added changelog for initial PosDealer API release

### DIFF
--- a/posdealer-api/2023-07-xx-posdealer-api-release.md
+++ b/posdealer-api/2023-07-xx-posdealer-api-release.md
@@ -1,0 +1,16 @@
+---
+authors: posdealer
+slug: posdealer-api/initial-release
+tags: [PosDealer API, API, Postman, Samples, Documentation]
+---
+
+# Launch of our PosDealer API
+We're happy to announce that we've just published our **new PosDealer API**! This API will help our commercial partners to automate the whole rollout process, which could previously only be performed via the Portal - from inviting PosOperators (merchants), to managing their master data and outlets, to creating subscriptions and CashBoxes.
+
+Further information can be found:
+- In the [API docs](https://docs.fiskaltrust.cloud/apis/posdealer-api)
+- In our [Postman sample collection](https://posdealer-samples.docs.fiskaltrust.cloud)
+
+Of course all this functionality will continue to be available in the Portal too, in case you prefer to use a graphical user interface over an API.
+
+Automating the invitation and rollout process is only the first iteration of this API. In future sprints, we will add more functionality to extend subscriptions, modify Middleware configurations, and much more.


### PR DESCRIPTION
Added a small changelog about the newly added PosDealer API.

Should only be released after finishing workitem [#59212](https://dev.azure.com/fiskaltrust/fiskaltrust/_workitems/edit/59212) and when the API docs are published.