### PR TITLE
Add availability note to surrogate banner release note (Sandbox now, Production soon)

### DIFF
--- a/portal/surrogate-context-banner.md
+++ b/portal/surrogate-context-banner.md
@@ -26,4 +26,4 @@ The new banner removes that ambiguity. At a glance, and on every page, you can s
 This update affects dealers and consultants who act on behalf of their operators. No action is required on your side — the banner appears automatically whenever you are working in an operator's account, and disappears as soon as you return to your own.
 
 ## Availability
-The banner is already live in the **Sandbox** environment, where you can try it out today. It will be rolled out to **Production** over the coming days, for **Austria** and **Germany**.
+The banner is already live in the **Sandbox** environment, where you can try it out today, and will be rolled out to **Production** across all markets over the coming days.

--- a/portal/surrogate-context-banner.md
+++ b/portal/surrogate-context-banner.md
@@ -23,4 +23,7 @@ The new banner removes that ambiguity. At a glance, and on every page, you can s
 ![surrogate-context-banner](images/surrogate-context-banner/surrogate-context-banner.gif)
 
 ## Impact
-This update is rolling out for **Austria** and **Germany**, and affects dealers and consultants who act on behalf of their operators. No action is required on your side — the banner appears automatically whenever you are working in an operator's account, and disappears as soon as you return to your own.
+This update affects dealers and consultants who act on behalf of their operators. No action is required on your side — the banner appears automatically whenever you are working in an operator's account, and disappears as soon as you return to your own.
+
+## Availability
+The banner is already live in the **Sandbox** environment, where you can try it out today. It will be rolled out to **Production** over the coming days, for **Austria** and **Germany**.


### PR DESCRIPTION
Follow-up to the merged surrogate-context-banner release note (#197).

Adds a dedicated **Availability** section stating the banner is already live in **Sandbox** and will roll out to **Production** across **all markets** over the coming days. Market scope moved out of *Impact* into *Availability* so the rollout story reads cleanly.

Wording kept as "over the coming days" (no hard date) since the note is a durable public page.